### PR TITLE
Disable openssh LoginGraceTime as fix for CVE-2024-6387

### DIFF
--- a/hosts/router/local_modules/default.nix
+++ b/hosts/router/local_modules/default.nix
@@ -16,9 +16,9 @@
     PasswordAuthentication = false;
     KbdInteractiveAuthentication = false;
     PermitRootLogin = lib.mkDefault "no";
-      # CVE-2024-6387
-      # https://github.com/NixOS/nixpkgs/pull/323753#issuecomment-2199762128
-      LoginGraceTime = 0;
+    # CVE-2024-6387
+    # https://github.com/NixOS/nixpkgs/pull/323753#issuecomment-2199762128
+    LoginGraceTime = 0;
   };
 
   services.openssh.extraConfig = "StreamLocalBindUnlink yes";

--- a/hosts/router/local_modules/default.nix
+++ b/hosts/router/local_modules/default.nix
@@ -16,6 +16,9 @@
     PasswordAuthentication = false;
     KbdInteractiveAuthentication = false;
     PermitRootLogin = lib.mkDefault "no";
+      # CVE-2024-6387
+      # https://github.com/NixOS/nixpkgs/pull/323753#issuecomment-2199762128
+      LoginGraceTime = 0;
   };
 
   services.openssh.extraConfig = "StreamLocalBindUnlink yes";


### PR DESCRIPTION
this should be reverted once nixos openssh is upgraded as this makes one vulnerable to a DOS attack.