### PR TITLE
Fix zone file creation and add bind test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 result*
+.vscode/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ colmena apply --on router
 nix flake update
 ```
 
+### VM Tests
+There are some VM tests in `checks/` testing some critical services. You can run them like this:
+```bash
+nix build .#checks.x86_64-linux.<check-name>
+```
+
+Note: `nix flake check` cannot be used as currently the repo is unformatted (formatter check is inherited from flakelight)
+
 ### Secrets
 
 * Manage secrets

--- a/checks/bind-test.nix
+++ b/checks/bind-test.nix
@@ -1,0 +1,15 @@
+pkgs:
+pkgs.testers.runNixOSTest {
+  name = "bind service";
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ ../hosts/router/dns.nix ];
+    };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("bind-create-dynamic-zones.service")
+    machine.wait_for_unit("bind.service")
+  '';
+}

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -1,0 +1,3 @@
+{
+  "bind-test" = import ./bind-test.nix;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,9 @@
         env.DIRENV_LOG_FORMAT = "";
       };
 
+
+      checks = import ./checks;
+
       outputs = {
         colmena = {
           meta = {

--- a/hosts/router/dns.nix
+++ b/hosts/router/dns.nix
@@ -25,17 +25,30 @@ let
   };
 in
 {
-  systemd.services.bind.preStart = ''
+  systemd.services."bind-create-dynamic-zones" = {
+    before = [ "bind.service" ];
+    after = [ "network.target" ];
+    wantedBy = [ "bind.service" ];
+    script = ''
     mkdir -p /var/lib/bind
     chown named /var/lib/bind
-    ${ concatStrings (map (zone: ''
+      ${concatStrings (
+        map (zone: ''
       if [[ ! -f /var/lib/bind/${zone}zone ]]; then
         cp "${templateFile}" "/var/lib/bind/${zone}zone"
       fi
       chmod 0644 "/var/lib/bind/${zone}zone"
       chown named "/var/lib/bind/${zone}zone"
-    '') dynamicZones) }
+        '') dynamicZones
+      )}
   '';
+    serviceConfig = {
+      Type = "oneshot";
+      User = "root";
+      RemainAfterExit = true;
+    };
+  };
+
   services.bind = {
     enable = true;
     cacheNetworks = [


### PR DESCRIPTION
The NixOS bind service was hardened here: https://github.com/NixOS/nixpkgs/commit/1cb6d223867d1da42267bd6e748714a0c984ebc5 That removed the write access to `/var/lib/bind` our pre start script needed.

Adds a one-shot unit running as root to now create theat file instead.

Also this introduces some infra to easily add nixos VM tests