### PR TITLE
Load kea hooks from nix store instead of /run

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -1,3 +1,4 @@
-{
+inputs: {
   "bind-test" = import ./bind-test.nix;
+  "kea-test" = import ./kea-test.nix inputs;
 }

--- a/checks/kea-test.nix
+++ b/checks/kea-test.nix
@@ -1,0 +1,37 @@
+inputs: pkgs:
+pkgs.testers.runNixOSTest {
+  name = "kea service";
+  nodes.machine =
+    { pkgs, lib, ... }:
+    {
+      imports = [
+        inputs.kea-lease-viewer.nixosModules.default
+        ../modules/secrets
+        ../hosts/router/dhcp.nix
+      ];
+
+      secrets.kea-ddns-key = {
+        enable = true;
+        encrypted = false;
+        source-path =
+          (pkgs.writeText "kea-ddns-key.gpg" (
+            builtins.toJSON {
+              name = "rndc-key";
+              algorithm = "hmac-sha256";
+              # "test-secret-key-for-testing"
+              secret = "dGVzdC1zZWNyZXQta2V5LWZvci10ZXN0aW5n";
+            }
+          )).outPath;
+      };
+
+      # Use available interfaces for testing (production uses voc, intern, hosting, guest)
+      services.kea.dhcp4.settings.interfaces-config = lib.mkForce {
+        interfaces = [ "eth0" ];
+      };
+    };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("kea-dhcp4-server.service")
+  '';
+}

--- a/checks/kea-test.nix
+++ b/checks/kea-test.nix
@@ -24,9 +24,23 @@ pkgs.testers.runNixOSTest {
           )).outPath;
       };
 
-      # Use available interfaces for testing (production uses voc, intern, hosting, guest)
-      services.kea.dhcp4.settings.interfaces-config = lib.mkForce {
-        interfaces = [ "eth0" ];
+      networking.vlans = {
+        intern = {
+          interface = "eth0";
+          id = 42;
+        };
+        hosting = {
+          interface = "eth0";
+          id = 37;
+        };
+        guest = {
+          interface = "eth0";
+          id = 12;
+        };
+        voc = {
+          interface = "eth0";
+          id = 23;
+        };
       };
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     flakelight.url = "github:nix-community/flakelight";
     flakelight.inputs.nixpkgs.follows = "nixpkgs";
   };
-  outputs = { nixpkgs, sops-nix, kea-lease-viewer, flakelight, ... }:
+  outputs = { nixpkgs, sops-nix, kea-lease-viewer, flakelight, ... }@inputs:
     flakelight ./. {
       inputs.nixpkgs = nixpkgs;
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
@@ -29,7 +29,7 @@
       };
 
 
-      checks = import ./checks;
+      checks = import ./checks inputs;
 
       outputs = {
         colmena = {
@@ -52,6 +52,9 @@
 
           router = { ... }: {
             deployment.targetHost = "router.xhain.space";
+            imports = [
+             kea-lease-viewer.nixosModules.default
+  ]         ;
           };
 
           files = { ... }: {

--- a/hosts/router/dhcp.nix
+++ b/hosts/router/dhcp.nix
@@ -65,10 +65,6 @@ let
   controlSocket = "/run/kea/dhcp4.sock";
 in
 {
-  imports = [
-    inputs.kea-lease-viewer.nixosModules.default
-  ];
-
   users.users.kea = {
     isSystemUser = true;
     group = "kea";
@@ -115,7 +111,7 @@ in
 
         hooks-libraries = [
           {
-            library = "/var/run/current-system/sw/lib/kea/hooks/libdhcp_lease_cmds.so";
+            library = "${pkgs.kea}/lib/kea/hooks/libdhcp_lease_cmds.so";
             parameters = {};
           }
         ];


### PR DESCRIPTION
I'm not 100% sure this is the prod issue as I have no access to the logs for that, however this is what got the VM test to pass locally.

Maybe there was a reason they were loaded from there? 

I refactored the kea module loading away from specialArgs as that is a bit painful to manage.